### PR TITLE
docs: update hyperlink example code

### DIFF
--- a/en-US/hyperlinks.html
+++ b/en-US/hyperlinks.html
@@ -63,11 +63,13 @@
   $9.</p>
   
   <pre class="code">
+var pepUrl = "http://www.python.org/dev/peps/pep-";
 var PEPRegexHandler = new ko.hyperlinks.RegexHandler(
       "Python Enhancement Proposals",
       new RegExp("PEP:\\s(\\d{4})"),            /* pattern to match */
-      ko.browse.openUrlInDefaultBrowser,
-      "http://www.python.org/dev/peps/pep-$1",  /* replacement string */
+      /* action function - called as 'fn(regexmatch)' */
+      function(match) { ko.browse.openUrlInDefaultBrowser(pepUrl + match[1]); },
+      null,  /* replacement string */
       /* which languages the handler is active in - 'null' for all */
       ['Python', 'Text', 'HTML'],
       Components.interfaces.ISciMoz.INDIC_PLAIN,


### PR DESCRIPTION
As the action function is more useful than the replace string, so the example should show that.
